### PR TITLE
Adding synthesis to streaming mode

### DIFF
--- a/docs/STREAMING.md
+++ b/docs/STREAMING.md
@@ -39,6 +39,12 @@ Most flags in [GENERATION.md](GENERATION.md), including config files, will work 
 
 If the target is experiencing SRTP decryption failure, it is likely receiving video traffic too fast. The `--packet-delay` flag can be used to slow down the RTP send rate. A delay of 50 ms works with most targets.
 
+## Serving a Single Video File
+
+You can stream a single video by saving it to json with the `--json` command, and then using the `--synth_from_json` command:
+
+```./h26forge stream --synth_from_json ~/crash.json --server --port 8787```
+
 ## Limitations
 
 The code is hard-coded to work with `stun:stun.l.google.com:19302` and the HTML JavaScript in this [JS Fiddle](https://jsfiddle.net/z7ms3u5r/).

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,7 @@ enum Commands {
         #[arg(long = "include-undefined-nalus")]
         include_undefined_nalus: bool,
         /// Seed value for the RNG
-        #[arg(short = 's', long)]
+        #[arg(short = 's', long, default_value="0")]
         seed: u64,
         /// Path to configuration file containing the ranges to use in random video generation
         #[arg(short = 'c', long)]
@@ -237,6 +237,9 @@ enum Commands {
         /// Server port
         #[arg(long = "port", default_value="0")]
         port: u32,
+        // synthesize JSON file
+        #[arg(long = "synth_from_json", default_value="")]
+        json: String,
     },
     /// Mux an encoded H.264 video into an MP4
     Mux {
@@ -1265,6 +1268,7 @@ fn main() {
             packet_delay,
             server,
             port,
+            json,
         }) => {
             if options.debug_encode {
                 let res = setup_debug_file(false, options.debug_encode, "", "streaming_output");
@@ -1304,6 +1308,7 @@ fn main() {
                 *packet_delay,
                 server,
                 *port,
+                json,
             );
         }
         Some(Commands::Randomize {

--- a/src/streaming/webrtc.rs
+++ b/src/streaming/webrtc.rs
@@ -276,7 +276,6 @@ pub async fn stream(
         let mut safe_start = true;
         
         if json_filename.is_empty() {
-
             let mut ind = 1;
             loop {
                 if status.load(Ordering::Relaxed) == 2 {
@@ -337,10 +336,7 @@ pub async fn stream(
             }
         } else {
             loop {
-                if status.load(Ordering::Relaxed) == 2 {
-                    println!("Stopping video generation");
-                    return;
-                } else if status.load(Ordering::Relaxed) == 1 {
+                if status.load(Ordering::Relaxed) == 1 {
                     println!("[Video] Generating from video JSON");
                     let mut decoded_elements = syntax_to_video(&json_filename);
                     let res = reencode_syntax_elements(
@@ -352,9 +348,10 @@ pub async fn stream(
                     );
                     let rtp = res.2;
                     packetize_and_send(&vid_tx, rtp, timestamp, seq_num, packet_delay).await;
-                    return;
+                    break;
                 }
             }
+            println!("All done - press ctrl-c to exit");
         }
     });
 


### PR DESCRIPTION
I've been finding that reproducing issues in stream mode with just a random seed is too clunky when the crash occurs after a long period of fuzzing. Adding synthesis from JSON, so single generated videos can be tested. Sample call:

./h26forge stream --synth_from_json ~/crash.json --server <IP> --port 8787

This will stream the video in crash.json to the target in server mode.

I wasn't sure how to design this. Add a flag to streaming mode? Add a flag to synthesize mode? Add a completely new mode? I picked the first, but feel free to change to whatever you feel is best.

